### PR TITLE
Added childIgnorekeys option and handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,19 @@ Metalsmith(__dirname)
 }));
 ```
 
-Accepts an array of keys to ignore in the output.
+Accepts an array of keys to ignore in the output. These keys are ignored regardless of where in the object hierarchy they appear.
+
+
+#### childIgnorekeys
+
+```js
+Metalsmith(__dirname)
+.use(writemetadata({
+  childIgnorekeys: ['next', 'previous', 'content']
+}));
+```
+
+Accepts an array of keys to ignore in the output if they are not a part of the root object.
 
 #### bufferencoding
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,7 @@ function plugin(opts){
   opts = opts || {};
   opts.pattern = opts.pattern || [];
   opts.ignorekeys = Array.isArray(opts.ignorekeys) ? opts.ignorekeys : [];
+  opts.childIgnorekeys = Array.isArray(opts.childIgnorekeys) ? opts.childIgnorekeys : [];
   opts.collections = opts.collections || {};
   opts.space = opts.space || '';
   opts.bufferencoding = opts.bufferencoding || false;
@@ -37,7 +38,7 @@ function plugin(opts){
           circularjson.stringify(
             files[file],
             function (k, v) {
-              if (opts.ignorekeys.indexOf(k) > -1) {
+              if (opts.ignorekeys.indexOf(k) > -1 || (this !== files[file] && opts.childIgnorekeys.indexOf(k) > -1)) {
                 return undefined;
               }
               return v;


### PR DESCRIPTION
Adds new feature for ignoring keys if they are on a child object, but does not filter if they are on the root object during output.

The Use Case:
I would like to have next/previous elements for each article. The default behavior causes the next/previous to cascade until all articles are included in each json.

Instead I want the next/previous elements in the json, but for each to just have an excerpt, title, etc for easy linking and usage.

By adding a childIgnoreKeys : ['parent', 'next', 'content'] I can stop the parent / next from cascading indefinitely.
