### PR TITLE
fix: avoid mutating files[file]

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,19 +30,26 @@ function plugin(opts){
         var json = basename(file, extname(file)) + '.json';
         if ('.' != dir) json = dir + '/' + json;
         debug('Write file ' + json);
-  
-        if(opts.bufferencoding && files[file] && files[file].contents && files[file].contents instanceof Buffer) {
-          files[file].contents = files[file].contents.toString(opts.bufferencoding); 
-        }
+
         data.contents = new Buffer(
           circularjson.stringify(
             files[file],
             function (k, v) {
-              if (opts.ignorekeys.indexOf(k) > -1 || (this !== files[file] && opts.childIgnorekeys.indexOf(k) > -1)) {
+              if (
+                (opts.ignorekeys.indexOf(k) > -1) ||
+                (this !== files[file] && opts.childIgnorekeys.indexOf(k) > -1)
+              ) {
                 return undefined;
               }
+              if (
+                (k == 'contents') &&
+                (opts.bufferencoding) &&
+                (v instanceof Buffer)
+              ) {
+                return v.toString(opts.bufferencoding)
+              }
               return v;
-            }, 
+            },
             opts.space
           )
         );
@@ -51,7 +58,7 @@ function plugin(opts){
       }
     });
 
-      
+
     Object.keys(opts.collections).forEach(function(key) {
       var collection = metadata.collections[key];
       var config = opts.collections[key] || {};
@@ -72,13 +79,13 @@ function plugin(opts){
           if(opts.bufferencoding) {
             for(var i in collection) {
               if(collection[i] && collection[i].contents && collection[i].contents instanceof Buffer) {
-                collection[i].contents =  collection[i].contents.toString(opts.bufferencoding); 
+                collection[i].contents =  collection[i].contents.toString(opts.bufferencoding);
               }
             }
           }
           contents.result = collection;
           contents = extend(contents, config.output.metadata);
-        } 
+        }
         data.contents = new Buffer(
           circularjson.stringify(
             contents,
@@ -96,6 +103,3 @@ function plugin(opts){
     });
   };
 }
-
-
-


### PR DESCRIPTION
converting `file[file].contents` to string breaks other plugins (like metalsmith-layouts), so I just added 'contents' to the stringify callback.